### PR TITLE
fix: remove NOT NULL constraints from Payments entity attributes

### DIFF
--- a/src/main/java/com/goodfood/payments/model/Payment.java
+++ b/src/main/java/com/goodfood/payments/model/Payment.java
@@ -31,15 +31,12 @@ public class Payment {
     @Size(max = 100)
     private String name;
 
-    @NotBlank
     @Size(max = 19)
     private String cardNumber;
 
-    @NotBlank
     @Size(max = 7)
     private String expiration;
 
-    @NotBlank
     @Size(min = 3, max = 3)
     private String code;
 

--- a/src/main/resources/db/migration/V2__alter_table_payment.sql
+++ b/src/main/resources/db/migration/V2__alter_table_payment.sql
@@ -1,0 +1,4 @@
+
+ALTER TABLE payments MODIFY COLUMN card_number varchar(19) DEFAULT NULL;
+ALTER TABLE payments MODIFY COLUMN expiration varchar(7) DEFAULT NULL;
+ALTER TABLE payments MODIFY COLUMN code varchar(3) DEFAULT NULL;


### PR DESCRIPTION
- Updated Flyway migrations to allow NULL values in card_number, expiration, and code fields.
- Removed @NotNull annotations from these attributes in the Payments entity.
- Adjusted behavior to avoid errors when inserting records without these fields.

Reason:
These changes were made to meet new requirements, allowing payments to be registered without requiring the above fields.

[fix: remove NOT NULL constraints from Payments entity attributes](https://github.com/RodrigoFernandes79/GoodFood-Payments-Microsservice/commit/0a7859318888e623ab2e5f834e7cbedf480753b1)